### PR TITLE
Testing and typing for setupRtl.options

### DIFF
--- a/src/setupRtl.test.tsx
+++ b/src/setupRtl.test.tsx
@@ -50,11 +50,11 @@ describe("setupRtl", () => {
     });
   });
 
-  describe("uses overriden, In-n-Out secret-menu options", () => {
+  describe("uses overidden options", () => {
     const text = "just something";
     const options = { container: document.createElement("div") };
 
-    it("passes overridden options into the render method", () => {
+    it("passed into the render method", () => {
       const renderView = setupRtl(MyComponent, { text });
 
       const { view } = renderView.options(options)();
@@ -62,7 +62,7 @@ describe("setupRtl", () => {
       expect(view.container).toBe(options.container);
     });
 
-    it("options are retained across calls to the method", () => {
+    it("and they are retained across calls to the method", () => {
       const renderView = setupRtl(MyComponent, { text });
 
       renderView.options(options)(); // Method call #1

--- a/src/setupRtl.test.tsx
+++ b/src/setupRtl.test.tsx
@@ -64,21 +64,37 @@ describe("setupRtl", () => {
     });
   });
 
-  it("passes overridden options into the render method", () => {
-    render.mockImplementation(); // We don't care about this method's inner workings
-
-    const text = "just something";
-    const options = { hydrate: true };
-
-    const renderView = setupRtl(MyComponent, { text });
-
-    renderView.options(options);
-    renderView();
-
-    expect(render).toHaveBeenCalledTimes(1);
-    expect(render).toHaveBeenCalledWith(<MyComponent text={text} />, options);
+  describe("uses overriden, In-n-Out secret-menu options", () => {
+    // We don't care about the inner workings of the method
+    beforeAll(() => render.mockImplementation());
 
     // Reset the mock so latter tests are unaffected
-    render.mockImplementation(jest.requireActual("@testing-library/react").render);
+    afterAll(() => render.mockImplementation(jest.requireActual("@testing-library/react").render));
+
+    it("passes overridden options into the render method", () => {
+      const text = "just something";
+      const options = { hydrate: true };
+
+      const renderView = setupRtl(MyComponent, { text });
+
+      renderView.options(options)();
+
+      expect(render).toHaveBeenCalledTimes(1);
+      expect(render).toHaveBeenCalledWith(<MyComponent text={text} />, options);
+    });
+
+    it("options are retained across calls to the method", () => {
+      const text = "just something";
+      const options = { hydrate: false };
+
+      const renderView = setupRtl(MyComponent, { text });
+
+      renderView.options(options);
+
+      renderView(); // Different method call
+
+      expect(render).toHaveBeenCalledTimes(1);
+      expect(render).toHaveBeenCalledWith(<MyComponent text={text} />, options);
+    });
   });
 });

--- a/src/setupRtl.test.tsx
+++ b/src/setupRtl.test.tsx
@@ -65,7 +65,7 @@ describe("setupRtl", () => {
     it("options are retained across calls to the method", () => {
       const renderView = setupRtl(MyComponent, { text });
 
-      renderView.options(options);
+      renderView.options(options)(); // Method call #1
 
       const { view } = renderView(); // Different method call
 

--- a/src/setupRtl.test.tsx
+++ b/src/setupRtl.test.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { setupRtl } from "./setupRtl";
 
 type MyComponentProps = {
@@ -11,8 +12,6 @@ const MyComponent: React.FC<MyComponentProps> = ({ text }: MyComponentProps) => 
 };
 
 describe("setupRtl", () => {
-  beforeEach(jest.clearAllMocks);
-
   it("uses a default prop value when not overridden", async () => {
     const text = "default";
     const renderView = setupRtl(MyComponent, { text });

--- a/src/setupRtl.test.tsx
+++ b/src/setupRtl.test.tsx
@@ -1,18 +1,5 @@
 import React from "react";
-
-import * as RenderRTL from "@testing-library/react";
-
 import { setupRtl } from "./setupRtl";
-
-// We mock the module and then immediately spyOn it because due to the read-only nature
-// of this module, we cannot spyOn it directly.
-// We create a mock that's the actual implementation in our mocked function as a poor-man's spyOn.
-jest.mock("@testing-library/react", () => ({
-  render: jest.fn(jest.requireActual("@testing-library/react").render),
-}));
-
-// Just a helpful way to reference our spy.
-const render = jest.spyOn(RenderRTL, "render");
 
 type MyComponentProps = {
   text: string;
@@ -65,36 +52,25 @@ describe("setupRtl", () => {
   });
 
   describe("uses overriden, In-n-Out secret-menu options", () => {
-    // We don't care about the inner workings of the method
-    beforeAll(() => render.mockImplementation());
-
-    // Reset the mock so latter tests are unaffected
-    afterAll(() => render.mockImplementation(jest.requireActual("@testing-library/react").render));
+    const text = "just something";
+    const options = { container: document.createElement("div") };
 
     it("passes overridden options into the render method", () => {
-      const text = "just something";
-      const options = { hydrate: true };
-
       const renderView = setupRtl(MyComponent, { text });
 
-      renderView.options(options)();
+      const { view } = renderView.options(options)();
 
-      expect(render).toHaveBeenCalledTimes(1);
-      expect(render).toHaveBeenCalledWith(<MyComponent text={text} />, options);
+      expect(view.container).toBe(options.container);
     });
 
     it("options are retained across calls to the method", () => {
-      const text = "just something";
-      const options = { hydrate: false };
-
       const renderView = setupRtl(MyComponent, { text });
 
       renderView.options(options);
 
-      renderView(); // Different method call
+      const { view } = renderView(); // Different method call
 
-      expect(render).toHaveBeenCalledTimes(1);
-      expect(render).toHaveBeenCalledWith(<MyComponent text={text} />, options);
+      expect(view.container).toBe(options.container);
     });
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,7 @@ export type RenderRtl<
   Component extends React.ComponentType,
   Props extends Partial<FullProps<Component>>
 > = RenderRtlMethod<Component, Props> & {
-  options: (options: RenderOptions) => RenderRtlMethod<Component, Props>;
+  options: (options: RenderOptions) => RenderRtl<Component, Props>;
 };
 
 type RenderRtlMethod<

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, RenderOptions } from "@testing-library/react";
 import { mount } from "enzyme";
 
 // This is just a helpful rename of the interface so we can read the below types more easily
@@ -16,7 +16,17 @@ export type RenderEnzyme<
   ...testProps: ConditionallyRequiredTestProps<Component, Props>
 ) => RenderEnzymeReturn<Component>;
 
+// Just like RenderEnzyme, but RenderRtl also allows callers to do `renderRtl.options({...})(props)`
+// In order to support both signature types, we extend the function's base type and add the options
+// attribute for those "in the know" ;)
 export type RenderRtl<
+  Component extends React.ComponentType,
+  Props extends Partial<FullProps<Component>>
+> = RenderRtlMethod<Component, Props> & {
+  options: (options: RenderOptions) => RenderRtlMethod<Component, Props>;
+};
+
+export type RenderRtlMethod<
   Component extends React.ComponentType,
   Props extends Partial<FullProps<Component>>
 > = (...testProps: ConditionallyRequiredTestProps<Component, Props>) => RenderRtlReturn<Component>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,14 +22,10 @@ export type RenderEnzyme<
 export type RenderRtl<
   Component extends React.ComponentType,
   Props extends Partial<FullProps<Component>>
-> = RenderRtlMethod<Component, Props> & {
+> = {
+  (...testProps: ConditionallyRequiredTestProps<Component, Props>): RenderRtlReturn<Component>;
   options: (options: RenderOptions) => RenderRtl<Component, Props>;
 };
-
-type RenderRtlMethod<
-  Component extends React.ComponentType,
-  Props extends Partial<FullProps<Component>>
-> = (...testProps: ConditionallyRequiredTestProps<Component, Props>) => RenderRtlReturn<Component>;
 
 type ConditionallyRequiredTestProps<
   Component extends React.ComponentType,

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,7 @@ export type RenderRtl<
   options: (options: RenderOptions) => RenderRtlMethod<Component, Props>;
 };
 
-export type RenderRtlMethod<
+type RenderRtlMethod<
   Component extends React.ComponentType,
   Props extends Partial<FullProps<Component>>
 > = (...testProps: ConditionallyRequiredTestProps<Component, Props>) => RenderRtlReturn<Component>;


### PR DESCRIPTION
Issue: #6 

So I'll start off by saying: this is perhaps more complicated than anticipated, but I legit tried to make it as simple as needed.

So the issues with testing the options functionality were twofold:
- ~I wanted to spyOn the `render` method, as it was the only way to confirm our code was executed properly without  attempting to test implementation details of `render`, which is a no-no. But it turns out JavaScript won't let us override an imported method like that (which is what `jest.spyOn` does), so I danced around it by using the mock-pathway and then re-implementing the actual logic lol. Wild.~
- In my testing, I found that `renderView.options` wasn't recognized as something I was allowed to call at all because the types weren't exposing that. So of course, I updated the `setup` return type to document the "hidden" attribute `.options` on the function. It's not well-known TS syntax ("it's not syntax the Jedi would have told you..."), so I'm open to changing it if there's something ya'll feel is better and still accomplishes the type we're looking for.

Lastly, I wanted to confirm that the functionality of the `options` is actually what we want. As it stands, editing `options` in one test will carry over to the next one. Is that intentional? It feels like a bit of a gotcha/test-pollution in that it would leave us vulnerable to the order of our tests mattering. Which it never should.

It wouldn't be wild to edit that, but I wanted to check.