### PR TITLE
Fixing RTL view type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { RenderResult } from "@testing-library/react";
 import { mount } from "enzyme";
 
 // This is just a helpful rename of the interface so we can read the below types more easily
@@ -56,7 +56,7 @@ interface RenderEnzymeReturn<Component extends React.ComponentType> {
 }
 interface RenderRtlReturn<Component extends React.ComponentType> {
   props: FullProps<Component>;
-  view: ReturnType<typeof render>;
+  view: RenderResult;
 }
 
 /**


### PR DESCRIPTION
For some reason it's not picking this one up properly (something about the method overload in `render` I'm guessing since it works fine for enzyme), so I've just reached in to grab the return type that it sets on itself.