### PR TITLE
Fixing `getProps` method on wrapper

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { RenderResult } from "@testing-library/react";
-import { mount, ReactWrapper } from "enzyme";
+import { ReactWrapper } from "enzyme";
 
 // This is just a helpful rename of the interface so we can read the below types more easily
 export type FullProps<C extends React.ComponentType> = React.ComponentProps<C>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { RenderResult } from "@testing-library/react";
-import { mount } from "enzyme";
+import { mount, ReactWrapper } from "enzyme";
 
 // This is just a helpful rename of the interface so we can read the below types more easily
 export type FullProps<C extends React.ComponentType> = React.ComponentProps<C>;
@@ -52,7 +52,7 @@ type RequiredKeys<T> = {
 
 interface RenderEnzymeReturn<Component extends React.ComponentType> {
   props: FullProps<Component>;
-  wrapper: ReturnType<typeof mount>;
+  wrapper: ReactWrapper<FullProps<Component>, React.ComponentState>;
 }
 interface RenderRtlReturn<Component extends React.ComponentType> {
   props: FullProps<Component>;


### PR DESCRIPTION
An issue that was noticed, where `wrapper.setProps(wrapper.getProps())` wouldn't be typed correctly. Fix't!