### PR TITLE
Added the ConnectedComponent type to the acceptable input components

### DIFF
--- a/src/setupEnzyme.test.tsx
+++ b/src/setupEnzyme.test.tsx
@@ -49,4 +49,13 @@ describe("setupEnzyme", () => {
       expect(wrapper.text()).toEqual(text);
     });
   });
+
+  it("can handle a pure function component", () => {
+    const text = "default";
+    const renderView = setupEnzyme(({ text }: MyComponentProps) => <div>{text}</div>);
+
+    const { wrapper } = renderView({ text });
+
+    expect(wrapper.text()).toEqual(text);
+  });
 });

--- a/src/setupEnzyme.tsx
+++ b/src/setupEnzyme.tsx
@@ -1,7 +1,12 @@
 import { mount } from "enzyme";
 import React from "react";
 
-import { RemainingPropsAndTestOverrides, FullProps, RenderEnzyme } from "./types";
+import {
+  RemainingPropsAndTestOverrides,
+  FullProps,
+  RenderEnzyme,
+  SetupComponentType,
+} from "./types";
 
 /**
  * Creates a `renderWrapper` function that can be used in unit tests to mount a component.
@@ -21,7 +26,7 @@ import { RemainingPropsAndTestOverrides, FullProps, RenderEnzyme } from "./types
  * ```
  */
 export function setupEnzyme<
-  ComponentType extends React.ComponentType,
+  ComponentType extends SetupComponentType,
   /* eslint-disable-next-line @typescript-eslint/ban-types */
   BaseProps extends Partial<FullProps<ComponentType>> = {}
 >(Component: ComponentType, baseProps?: BaseProps): RenderEnzyme<ComponentType, BaseProps> {

--- a/src/setupRtl.test.tsx
+++ b/src/setupRtl.test.tsx
@@ -72,4 +72,13 @@ describe("setupRtl", () => {
       expect(view.container).toBe(options.container);
     });
   });
+
+  it("can handle a pure function component", () => {
+    const text = "default";
+    const renderView = setupRtl(({ text }: MyComponentProps) => <div>{text}</div>);
+
+    const { view } = renderView({ text });
+
+    view.getByText(text);
+  });
 });

--- a/src/setupRtl.tsx
+++ b/src/setupRtl.tsx
@@ -31,7 +31,7 @@ export function setupRtl<
     const props = {
       ...baseProps,
       ...testProps,
-    } as React.ComponentProps<ComponentType>;
+    } as FullProps<ComponentType>;
     const view = render(<Component {...(props as any)} />, options);
 
     return { props, view };

--- a/src/setupRtl.tsx
+++ b/src/setupRtl.tsx
@@ -1,7 +1,7 @@
 import { render, RenderOptions } from "@testing-library/react";
 import React from "react";
 
-import { RemainingPropsAndTestOverrides, FullProps, RenderRtl } from "./types";
+import { RemainingPropsAndTestOverrides, FullProps, RenderRtl, SetupComponentType } from "./types";
 
 /**
  * Creates a `renderView` function that can be used in unit tests to mount a component.
@@ -21,7 +21,7 @@ import { RemainingPropsAndTestOverrides, FullProps, RenderRtl } from "./types";
  * ```
  */
 export function setupRtl<
-  ComponentType extends React.ComponentType,
+  ComponentType extends SetupComponentType,
   /* eslint-disable-next-line @typescript-eslint/ban-types */
   BaseProps extends Partial<FullProps<ComponentType>> = {}
 >(Component: ComponentType, baseProps?: BaseProps): RenderRtl<ComponentType, BaseProps> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,13 +1,20 @@
 import { RenderOptions, RenderResult } from "@testing-library/react";
 import { ReactWrapper } from "enzyme";
+import { ReactElement } from "react";
 
-export type SetupComponentType = React.ComponentType | ((props?: any) => React.ReactNode);
+// eslint-disable-next-line @typescript-eslint/ban-types
+interface PureFunctionComponent<P = {}> {
+  (props?: P): ReactElement<any, any> | null;
+}
+export type SetupComponentType = React.ComponentType | PureFunctionComponent;
 
 // This is just a helpful rename of the interface so we can read the below types more easily
-export type FullProps<C extends React.ComponentType> = React.ComponentProps<C>;
+export type FullProps<C extends SetupComponentType> = C extends React.ComponentType
+  ? React.ComponentProps<C>
+  : PureFunctionComponent<C>;
 
 export type RenderEnzyme<
-  Component extends React.ComponentType,
+  Component extends SetupComponentType,
   Props extends Partial<FullProps<Component>>
 > = (
   // By using the spread operator in this type, we leverage the optionality of the entire argument itself.
@@ -22,7 +29,7 @@ export type RenderEnzyme<
 // In order to support both signature types, we extend the function's base type and add the options
 // attribute for those "in the know" ;)
 export type RenderRtl<
-  Component extends React.ComponentType,
+  Component extends SetupComponentType,
   Props extends Partial<FullProps<Component>>
 > = {
   (...testProps: ConditionallyRequiredTestProps<Component, Props>): RenderRtlReturn<Component>;
@@ -30,7 +37,7 @@ export type RenderRtl<
 };
 
 type ConditionallyRequiredTestProps<
-  Component extends React.ComponentType,
+  Component extends SetupComponentType,
   Props extends Partial<FullProps<Component>>
 > =
   // This is where the real magic happens. At type-interpretation time, the compiler can infer from the
@@ -58,11 +65,11 @@ type RequiredKeys<T> = {
   [K in keyof T]-?: Record<string, unknown> extends { [P in K]: T[K] } ? never : K;
 }[keyof T];
 
-interface RenderEnzymeReturn<Component extends React.ComponentType> {
+interface RenderEnzymeReturn<Component extends SetupComponentType> {
   props: FullProps<Component>;
   wrapper: ReactWrapper<FullProps<Component>, React.ComponentState>;
 }
-interface RenderRtlReturn<Component extends React.ComponentType> {
+interface RenderRtlReturn<Component extends SetupComponentType> {
   props: FullProps<Component>;
   view: RenderResult;
 }
@@ -74,12 +81,12 @@ interface RenderRtlReturn<Component extends React.ComponentType> {
  * * Optional: any overrides for the base props
  */
 export type RemainingPropsAndTestOverrides<
-  ComponentType extends React.ComponentType,
+  ComponentType extends SetupComponentType,
   BaseProps extends Partial<FullProps<ComponentType>>
 > = RemainingProps<ComponentType, BaseProps> &
   Pick<Partial<FullProps<ComponentType>>, keyof FullProps<ComponentType>>;
 
 type RemainingProps<
-  ComponentType extends React.ComponentType,
+  ComponentType extends SetupComponentType,
   BaseProps extends Partial<FullProps<ComponentType>>
 > = Omit<FullProps<ComponentType>, keyof BaseProps>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,8 @@
 import { RenderOptions, RenderResult } from "@testing-library/react";
 import { ReactWrapper } from "enzyme";
 
+export type SetupComponentType = React.ComponentType | ((props?: any) => React.ReactNode);
+
 // This is just a helpful rename of the interface so we can read the below types more easily
 export type FullProps<C extends React.ComponentType> = React.ComponentProps<C>;
 


### PR DESCRIPTION
While using this library, I found the type system fighting me when using a `connect`ed component. But I believe our vision of Total Testing Dominance is for our helpers/patterns to be easy to use regardless of the component in question. This edit seeks to do that.

I'm not confident, however, how we feel about including these redux libraries into the dependencies. For Codecademy, this is obviously fine. But for a public library, this might not be, and I wanted to be sensitive to that.