### PR TITLE
Fixed prop types inference for non-React.FC-declared functions

### DIFF
--- a/src/setupEnzyme.test.tsx
+++ b/src/setupEnzyme.test.tsx
@@ -54,8 +54,8 @@ describe("setupEnzyme", () => {
     const text = "default";
     const renderView = setupEnzyme(({ text }: MyComponentProps) => <div>{text}</div>);
 
-    const { wrapper } = renderView({ text });
+    const { props, wrapper } = renderView({ text });
 
-    expect(wrapper.text()).toEqual(text);
+    expect(wrapper.text()).toEqual(props.text);
   });
 });

--- a/src/setupRtl.test.tsx
+++ b/src/setupRtl.test.tsx
@@ -77,8 +77,8 @@ describe("setupRtl", () => {
     const text = "default";
     const renderView = setupRtl(({ text }: MyComponentProps) => <div>{text}</div>);
 
-    const { view } = renderView({ text });
+    const { props, view } = renderView({ text });
 
-    view.getByText(text);
+    view.getByText(props.text);
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,10 +8,15 @@ interface PureFunctionComponent<P = {}> {
 }
 export type SetupComponentType = React.ComponentType | PureFunctionComponent;
 
-// This is just a helpful rename of the interface so we can read the below types more easily
+// Given a C component type, extracts the props of it:
+// * If C is an explicitly declared React.Component subclass or React.FC, we can use React.ComponentProps
+// * Otherewise if it's a regular function, we can extract its first parameter as the props
+// * If not, we give up...
 export type FullProps<C extends SetupComponentType> = C extends React.ComponentType
   ? React.ComponentProps<C>
-  : PureFunctionComponent<C>;
+  : C extends PureFunctionComponent
+  ? Parameters<C>[0]
+  : unknown;
 
 export type RenderEnzyme<
   Component extends SetupComponentType,


### PR DESCRIPTION
Right now they get inferred to be the type of the component itself, rather than the first parameter.