### PR TITLE
Add `update` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,32 @@ describe("MyComponent", () => {
 });
 ```
 
+### Updating Props
+
+Often you'd like to test lifecycle methods/hooks and `component-test-setup` is written to help accommodate that.
+
+For both RTL and Enzyme the API is the same, the `update` method returned in the `render*` method:
+
+```js
+const renderWrapper = setupEnzyme(MyComponent, {
+  someProp: "value",
+});
+
+describe("MyComponent", () => {
+  it("does a thing", () => {
+    const { wrapper, update } = renderWrapper({
+      some: "otherProp",
+    });
+
+    update({ someProp: "another-value" });
+
+    wrapper.getByText("another-value"); // It has been updated to render with the new someProp value
+  });
+});
+```
+
+Please note: This currently _does not_ update the `props` object that's returned in the `render*` method. It will be locked into whatever the initial completed props were for the first render.
+
 ### TypeScript Usage
 
 `component-test-setup` is written in TypeScript and generally type safe.

--- a/src/setupEnzyme.test.tsx
+++ b/src/setupEnzyme.test.tsx
@@ -11,9 +11,11 @@ const MyComponent: React.FC<MyComponentProps> = ({ text }: MyComponentProps) => 
   return <div>{text}</div>;
 };
 
+const text = "default";
+const overridden = "overridden";
+
 describe("setupEnzyme", () => {
   it("uses a default prop value when not overridden", async () => {
-    const text = "default";
     const renderWrapper = setupEnzyme(MyComponent, { text });
 
     const { wrapper } = renderWrapper();
@@ -22,17 +24,26 @@ describe("setupEnzyme", () => {
   });
 
   it("uses an overridden prop value when not overridden", async () => {
-    const text = "overridden";
-    const renderWrapper = setupEnzyme(MyComponent, { text: "default" });
+    const renderWrapper = setupEnzyme(MyComponent, { text });
 
-    const { wrapper } = renderWrapper({ text });
+    const { wrapper } = renderWrapper({ text: overridden });
+
+    expect(wrapper.text()).toEqual(overridden);
+  });
+
+  it("updates view with new props when passed", () => {
+    const renderView = setupEnzyme(MyComponent, { text });
+
+    const { wrapper, update } = renderView();
 
     expect(wrapper.text()).toEqual(text);
+
+    update({ text: overridden });
+
+    expect(wrapper.text()).toEqual(overridden);
   });
 
   describe("enforces that required props that are missing in the initial setup are provided in the render method", () => {
-    const text = "default";
-
     it("when props are completely absent", async () => {
       const renderWrapper = setupEnzyme(MyComponent);
 
@@ -51,7 +62,6 @@ describe("setupEnzyme", () => {
   });
 
   it("can handle a pure function component", () => {
-    const text = "default";
     const renderView = setupEnzyme(({ text }: MyComponentProps) => <div>{text}</div>);
 
     const { props, wrapper } = renderView({ text });

--- a/src/setupEnzyme.tsx
+++ b/src/setupEnzyme.tsx
@@ -39,6 +39,6 @@ export function setupEnzyme<
     } as FullProps<ComponentType>;
     const wrapper = mount(<Component {...(props as any)} />);
 
-    return { props, wrapper };
+    return { props, wrapper, update: wrapper.setProps };
   };
 }

--- a/src/setupEnzyme.tsx
+++ b/src/setupEnzyme.tsx
@@ -39,6 +39,10 @@ export function setupEnzyme<
     } as FullProps<ComponentType>;
     const wrapper = mount(<Component {...(props as any)} />);
 
-    return { props, wrapper, update: wrapper.setProps };
+    // setProps demands _something_ be passed, so we keep that going, too
+    const update = (updatedProps: Pick<FullProps<ComponentType>, keyof FullProps<ComponentType>>) =>
+      wrapper.setProps(updatedProps);
+
+    return { props, wrapper, update };
   };
 }

--- a/src/setupRtl.test.tsx
+++ b/src/setupRtl.test.tsx
@@ -11,9 +11,11 @@ const MyComponent: React.FC<MyComponentProps> = ({ text }: MyComponentProps) => 
   return <div>{text}</div>;
 };
 
+const text = "default";
+const overridden = "overridden";
+
 describe("setupRtl", () => {
   it("uses a default prop value when not overridden", async () => {
-    const text = "default";
     const renderView = setupRtl(MyComponent, { text });
 
     const { view } = renderView();
@@ -22,17 +24,26 @@ describe("setupRtl", () => {
   });
 
   it("uses an overridden prop value when not overridden", async () => {
-    const text = "overridden";
-    const renderView = setupRtl(MyComponent, { text: "default" });
+    const renderView = setupRtl(MyComponent, { text });
 
-    const { view } = renderView({ text });
+    const { view } = renderView({ text: overridden });
+
+    view.getByText(overridden);
+  });
+
+  it("updates view with new props when passed", () => {
+    const renderView = setupRtl(MyComponent, { text });
+
+    const { view, update } = renderView();
 
     view.getByText(text);
+
+    update({ text: overridden });
+
+    view.getByText(overridden);
   });
 
   describe("enforces that required props that are missing in the initial setup are provided in the render method", () => {
-    const text = "default";
-
     it("when props are completely absent", async () => {
       const renderView = setupRtl(MyComponent);
 
@@ -51,7 +62,6 @@ describe("setupRtl", () => {
   });
 
   describe("uses overidden options", () => {
-    const text = "just something";
     const options = { container: document.createElement("div") };
 
     it("passed into the render method", () => {
@@ -74,7 +84,6 @@ describe("setupRtl", () => {
   });
 
   it("can handle a pure function component", () => {
-    const text = "default";
     const renderView = setupRtl(({ text }: MyComponentProps) => <div>{text}</div>);
 
     const { props, view } = renderView({ text });

--- a/src/setupRtl.tsx
+++ b/src/setupRtl.tsx
@@ -33,8 +33,10 @@ export function setupRtl<
       ...testProps,
     } as FullProps<ComponentType>;
     const view = render(<Component {...(props as any)} />, options);
+    const update = (updatedProps: Partial<FullProps<ComponentType>>) =>
+      view.rerender(<Component {...(props as any)} {...updatedProps} />);
 
-    return { props, view };
+    return { props, view, update };
   }
 
   renderView.options = (newOptions: RenderOptions) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,8 +93,7 @@ interface BaseRenderReturn<Component extends SetupComponentType> {
 export type RemainingPropsAndTestOverrides<
   ComponentType extends SetupComponentType,
   BaseProps extends Partial<FullProps<ComponentType>>
-> = RemainingProps<ComponentType, BaseProps> &
-  Pick<Partial<FullProps<ComponentType>>, keyof FullProps<ComponentType>>;
+> = RemainingProps<ComponentType, BaseProps> & Partial<FullProps<ComponentType>>;
 
 type RemainingProps<
   ComponentType extends SetupComponentType,

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,13 +70,18 @@ type RequiredKeys<T> = {
   [K in keyof T]-?: Record<string, unknown> extends { [P in K]: T[K] } ? never : K;
 }[keyof T];
 
-interface RenderEnzymeReturn<Component extends SetupComponentType> {
-  props: FullProps<Component>;
+interface RenderEnzymeReturn<Component extends SetupComponentType>
+  extends BaseRenderReturn<Component> {
   wrapper: ReactWrapper<FullProps<Component>, React.ComponentState>;
 }
-interface RenderRtlReturn<Component extends SetupComponentType> {
-  props: FullProps<Component>;
+interface RenderRtlReturn<Component extends SetupComponentType>
+  extends BaseRenderReturn<Component> {
   view: RenderResult;
+}
+
+interface BaseRenderReturn<Component extends SetupComponentType> {
+  props: FullProps<Component>;
+  update: (updatedProps?: Partial<FullProps<Component>>) => void;
 }
 
 /**


### PR DESCRIPTION
Resolving #14, the `render*` methods now have an `update` method on them to quickly/simply update the props of a given component without all the unneeded overhead.

I updated the readme to indicate that the `props` from the initial render will not change. If this is a thing we actually want, we probably want to change it to a getter function like `getProps()` so it's always as up-to-date at the time of calling.

I didn't want this to creep beyond the initial use-case though without further discussion here.