### PR TITLE
Exporting return types for setupEnzyme and setupRtl

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -70,11 +70,11 @@ type RequiredKeys<T> = {
   [K in keyof T]-?: Record<string, unknown> extends { [P in K]: T[K] } ? never : K;
 }[keyof T];
 
-interface RenderEnzymeReturn<Component extends SetupComponentType>
+export interface RenderEnzymeReturn<Component extends SetupComponentType>
   extends BaseRenderReturn<Component> {
   wrapper: ReactWrapper<FullProps<Component>, React.ComponentState>;
 }
-interface RenderRtlReturn<Component extends SetupComponentType>
+export interface RenderRtlReturn<Component extends SetupComponentType>
   extends BaseRenderReturn<Component> {
   view: RenderResult;
 }


### PR DESCRIPTION
I need these types to properly type `setupRtlWithRedux`/`setupEnzymeWithRedux` from the [Redux Testing Improvements RFC](https://www.notion.so/codecademy/Redux-Testing-Improvements-c0c559ffd6ff48baa635152d008b46f7). 