### PR TITLE
Reduce complexity of FullProps type (take 2)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -9,14 +9,7 @@ interface PureFunctionComponent<P = {}> {
 export type SetupComponentType = React.ComponentType<any> | PureFunctionComponent;
 
 // Given a C component type, extracts the props of it:
-// * If C is an explicitly declared React.Component subclass or React.FC, we can use React.ComponentProps
-// * Otherewise if it's a regular function, we can extract its first parameter as the props
-// * If not, we give up...
-export type FullProps<C extends SetupComponentType> = C extends React.ComponentType
-  ? React.ComponentProps<C>
-  : C extends PureFunctionComponent
-  ? Parameters<C>[0]
-  : unknown;
+export type FullProps<C extends SetupComponentType> = React.ComponentProps<C>
 
 export type RenderEnzyme<
   Component extends SetupComponentType,


### PR DESCRIPTION
Effectively reverting #12.

Hey there Codecademy/open-source people!

Recently I was using this in a project that had primarily functional components, ie:
```ts
type Props = {
  a: string;
  b?: number
};

export function ComponentDealie({a, b}: Props) {
  return <div />;
}
```

And the inferred type of the props for the component and subsequent types down the chain of uses (`renderView` callback, missing/overriding props, the `prop` return value) were all coming back as `unknown`.

It would seem that TS's ability to determine if a passed component extends `React.ComponentProps` is not as strong as `React.ComponentProps`'s ability to parse the props from functional components.

In my testing, reverting this line fixed everything (and didn't break anything).