### PR TITLE
Attempt at fixing the deploy pipeline

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,6 +11,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        command: ["eslint", "prettier", "test:ci", "tsc"]
+        command: ["eslint", "prettier", "test:ci", "compile"]
 
 on: push

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "prettier:write": "npm run prettier -- --write",
     "test": "jest",
     "test:ci": "jest --maxWorkers=2",
-    "tsc": "tsc --module commonjs"
+    "compile": "tsc --module commonjs"
   },
   "types": "src/index.d.ts",
   "version": "0.3.2"

--- a/package.json
+++ b/package.json
@@ -60,5 +60,5 @@
     "compile": "tsc --module commonjs"
   },
   "types": "src/index.d.ts",
-  "version": "0.3.2"
+  "version": "0.3.3"
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,14 +9,7 @@ interface PureFunctionComponent<P = {}> {
 export type SetupComponentType = React.ComponentType<any> | PureFunctionComponent;
 
 // Given a C component type, extracts the props of it:
-// * If C is an explicitly declared React.Component subclass or React.FC, we can use React.ComponentProps
-// * Otherewise if it's a regular function, we can extract its first parameter as the props
-// * If not, we give up...
-export type FullProps<C extends SetupComponentType> = C extends React.ComponentType
-  ? React.ComponentProps<C>
-  : C extends PureFunctionComponent
-  ? Parameters<C>[0]
-  : unknown;
+export type FullProps<C extends SetupComponentType> = React.ComponentProps<C>
 
 export type RenderEnzyme<
   Component extends SetupComponentType,


### PR DESCRIPTION
In a recent merge, [the deploy to update the package failed](https://github.com/Codecademy/component-test-setup/actions/runs/8743163983/job/23993084761).

This seems to be because of [the next most recent code-change PR](https://github.com/Codecademy/component-test-setup/pull/22/files), which migrated the pipeline to GHA, but seems to be missing the compilation step.

My guess is that the `tsc` step (typescript compiler) is the step we're looking for. 

And because we're technically changing something about this package, let's update the version of it too.